### PR TITLE
Fix compilation without X86 or GFXBOARD support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_PREREQ([2.67])
+AC_PREREQ([2.72])
 
 m4_define([fsbuild_version], [0.0.0])
 m4_define([fsbuild_version_major], [0])
@@ -9,8 +9,7 @@ m4_define([fsbuild_version_minor], [0])
 m4_define([fsbuild_version_revision], [0])
 m4_define([fsbuild_commit], [])
 
-AC_INIT([FS-UAE], [fsbuild_version],
-        [frode@fs-uae.net], [fs-uae], [https://fs-uae.net])
+AC_INIT([FS-UAE],[fsbuild_version],[frode@fs-uae.net],[fs-uae],[https://fs-uae.net])
 AC_CONFIG_AUX_DIR([.])
 AC_CANONICAL_HOST
 AC_CONFIG_SRCDIR([src/main.cpp])
@@ -691,29 +690,29 @@ AS_CASE([$host_os],
 # Byte swapping
 
 AC_MSG_CHECKING(for bswap_16)
-AC_TRY_LINK([
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 	#if HAVE_BYTESWAP_H
 	# include <byteswap.h>
 	#endif
-], [
+]], [[
 	bswap_16(0x12);
-], [
+]])],[
 	AC_DEFINE(HAVE_BSWAP_16, 1, [Define to 1 if you have the 'bswap_16' function.])
 	AC_MSG_RESULT(yes)
-], [
+],[
 	AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for bswap_32)
-AC_TRY_LINK([
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 	#if HAVE_BYTESWAP_H
 	# include <byteswap.h>
 	#endif
-], [
+]], [[
 	bswap_32(0x1234);
-], [
+]])],[
 	AC_DEFINE(HAVE_BSWAP_32, 1, [Define to 1 if you have the 'bswap_32' function.])
 	AC_MSG_RESULT(yes)
-], [
+],[
 	AC_MSG_RESULT(no)
 ])
 
@@ -802,22 +801,27 @@ DIS_FEATURE([FSE_DRIVERS], [drivers], [drivers],
             [multiple driver backends (experimental)])
 REQ_FEATURE([FSEMU], [fsemu], [fsemu],
             [new FSEMU backend (experimental)])
+
+AS_IF([test "x$enable_x86" != xno], [
+  enable_gfxboard=no
+ ])
+
 OPT_FEATURE([GFXBOARD], [gfxboard], [gfxboard],
             [GFX hardware boards])
 
 AC_ARG_ENABLE([jit], [AS_HELP_STRING([--disable-jit], [JIT compiler])])
 AS_IF([test "x$enable_jit" != xno], [
-    AC_TRY_COMPILE([
-    ], [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    ]], [[
         #if !defined(__i386__) && !defined(__x86_64__)
         #error JIT is only supported on x86/x86-64
         #endif
         #if defined(__OpenBSD__) || defined(__FreeBSD__)
         #error no JIT on OpenBSD/FreeBSD right now
         #endif
-    ], [
+    ]])],[
         AC_DEFINE([JIT], [1], [Define to 1 to enable JIT compilation])
-    ], [
+    ],[
         if test "x$enable_jit" = xyes; then
             AC_MSG_FAILURE(
                 [JIT is not supported on $host])
@@ -885,14 +889,14 @@ OPT_FEATURE([WITH_VPAR], [vpar], [vpar],
 
 AC_ARG_ENABLE([x86], [AS_HELP_STRING([--disable-x86], [x86 bridgeboard support])])
 AS_IF([test "x$enable_x86" != xno], [
-    AC_TRY_COMPILE([
-    ], [
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    ]], [[
         #if !defined(__i386__) && !defined(__x86_64__)
         #error Bridgeboard is only supported on x86/x86-64
         #endif
-    ], [
+    ]])],[
         AC_DEFINE([WITH_X86], [1], [Define to 1 to enable x86 bridgeboard support])
-    ], [
+    ],[
         if test "x$enable_x86" = xyes; then
             AC_MSG_FAILURE(
                 [x86 bridgeboard is not supported on $host])

--- a/src/ar.cpp
+++ b/src/ar.cpp
@@ -271,12 +271,17 @@ static int stored_picasso_on = -1;
 
 static void cartridge_enter(void)
 {
+#ifdef GFXBOARD
 	stored_picasso_on = gfxboard_set(0, false) ? 1 : 0;
+#endif
 }
 static void cartridge_exit (void)
 {
-	if (stored_picasso_on > 0)
+	if (stored_picasso_on > 0) {
+#ifdef GFXBOARD
 		gfxboard_set(0, true);
+#endif
+	}
 	stored_picasso_on = -1;
 }
 

--- a/src/cfgfile.cpp
+++ b/src/cfgfile.cpp
@@ -2798,6 +2798,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 	cfgfile_writeramboard(p, f, _T("cpuboardmem1"), 0, &p->cpuboardmem1);
 	cfgfile_dwrite(f, _T("cpuboardmem2_size"), _T("%d"), p->cpuboardmem2.size / 0x100000);
 	cfgfile_writeramboard(p, f, _T("cpuboardmem2"), 0, &p->cpuboardmem2);
+#ifdef GFXBOARD
 	cfgfile_write_bool(f, _T("gfxcard_hardware_vblank"), p->rtg_hardwareinterrupt);
 	cfgfile_write_bool(f, _T("gfxcard_hardware_sprite"), p->rtg_hardwaresprite);
 	cfgfile_dwrite_bool(f, _T("gfxcard_overlay"), p->rtg_overlay);
@@ -2837,6 +2838,7 @@ void cfgfile_save_options (struct zfile *f, struct uae_prefs *p, int type)
 			}
 		}
 	}
+#endif
 	cfgfile_write (f, _T("chipmem_size"), _T("%d"), p->chipmem.size == 0x20000 ? -1 : (p->chipmem.size == 0x40000 ? 0 : p->chipmem.size / 0x80000));
 	cfgfile_writeramboard(p, f, _T("chipmem"), 0, &p->chipmem);
 
@@ -6087,6 +6089,7 @@ static int cfgfile_parse_hardware (struct uae_prefs *p, const TCHAR *option, TCH
 		return 1;
 	}
 
+#ifdef GFXBOARD
 	for (int i = 0; i < MAX_RTG_BOARDS; i++) {
 		struct rtgboardconfig *rbc = &p->rtgboards[i];
 		TCHAR tmp[100];
@@ -6135,6 +6138,7 @@ static int cfgfile_parse_hardware (struct uae_prefs *p, const TCHAR *option, TCH
 			return 1;
 		}
 	}
+#endif
 
 	if (cfgfile_string(option, value, _T("cpuboard_type"), tmpbuf, sizeof tmpbuf / sizeof(TCHAR))) {
 		p->cpuboard_type = 0;
@@ -6501,6 +6505,7 @@ void cfgfile_compatibility_rtg(struct uae_prefs *p)
 			}
 		}
 	}
+#if GFXBOARD
 	int rtgs[MAX_RTG_BOARDS] = { 0 };
 	for (int i = 0; i < MAX_RTG_BOARDS; i++) {
 		if (p->rtgboards[i].rtgmem_size && !rtgs[i]) {
@@ -6537,6 +6542,7 @@ void cfgfile_compatibility_rtg(struct uae_prefs *p)
 			}
 		}
 	}
+#endif
 }
 
 void cfgfile_compatibility_romtype(struct uae_prefs *p)

--- a/src/devices.cpp
+++ b/src/devices.cpp
@@ -279,7 +279,9 @@ void devices_update_sound(float clk, float syncadjust)
 	update_sound (clk);
 	update_sndboard_sound (clk / syncadjust);
 	update_cda_sound(clk / syncadjust);
+#ifdef WITH_X86
 	x86_update_sound(clk / syncadjust);
+#endif
 }
 
 void devices_update_sync(float svpos, float syncadjust)
@@ -315,7 +317,9 @@ void virtualdevice_free(void)
 #ifdef WITH_LUA
 	uae_lua_free();
 #endif
+#if GFXBOARD
 	gfxboard_free();
+#endif
 	savestate_free();
 	memory_cleanup();
 	free_shm();
@@ -403,7 +407,9 @@ void devices_restore_start(void)
 
 void devices_syncchange(void)
 {
+#ifdef WITH_X86
 	x86_bridge_sync_change();
+#endif
 }
 
 void devices_pause(void)

--- a/src/drawing.cpp
+++ b/src/drawing.cpp
@@ -5043,10 +5043,12 @@ void full_redraw_all(void)
 			redraw = true;
 		}
 	}
+#if GFXBOARD
 	if (ad->picasso_on) {
 		gfxboard_refresh(monid);
 		redraw = true;
 	}
+#endif
 	if (redraw) {
 		render_screen(0, 1, true);
 		show_screen(0, 0);

--- a/src/expansion.cpp
+++ b/src/expansion.cpp
@@ -4691,6 +4691,7 @@ static const struct expansionboardsettings cubo_settings[] = {
 	}
 };
 
+#ifdef WITH_X86
 static struct expansionboardsettings x86_mouse_settings[] = {
 	{
 		_T("Amiga port\0") _T("1\0") _T("2\0"),
@@ -4706,6 +4707,7 @@ static struct expansionboardsettings x86_mouse_settings[] = {
 		NULL
 	}
 };
+#endif
 
 static struct expansionboardsettings sb_isa_settings[] = {
 	{
@@ -5806,6 +5808,7 @@ const struct expansionromtype expansionroms[] = {
 		_T("amax"), _T("AMAX ROM dongle"), _T("ReadySoft"),
 		NULL, NULL, NULL, NULL, ROMTYPE_AMAX | ROMTYPE_NONE, 0, 0, 0, false
 	},
+#ifdef WITH_X86
 	{
 		_T("x86athdprimary"), _T("AT IDE Primary"), NULL,
 		NULL, x86_at_hd_init_1, NULL, x86_add_at_hd_unit_1, ROMTYPE_X86_AT_HD1 | ROMTYPE_NOT, 0, 0, BOARD_NONAUTOCONFIG_AFTER_Z2, true,
@@ -5829,6 +5832,7 @@ const struct expansionromtype expansionroms[] = {
 		false, 0, x86_rt1000_settings
 
 	},
+#endif
 #ifndef NDEBUG
 	{
 		_T("dev_ide"), _T("DEV IDE"), NULL,
@@ -5843,6 +5847,7 @@ const struct expansionromtype expansionroms[] = {
 
 	/* PC Bridgeboards */
 
+#ifdef WITH_X86
 	{
 		_T("a1060"), _T("A1060 Sidecar"), _T("Commodore"),
 		NULL, a1060_init, NULL, NULL, ROMTYPE_A1060 | ROMTYPE_NONE, 0, 0, BOARD_AUTOCONFIG_Z2, true,
@@ -5883,6 +5888,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, x86at386_bridge_settings
 	},
+#endif
 
 	// only here for rom selection and settings
 	{
@@ -5989,6 +5995,7 @@ const struct expansionromtype expansionroms[] = {
 		false, 0, NULL,
 		{ 0x80, 2, 0x10, 0x00, 6502 >> 8, 6502 & 255, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }
 	},
+#ifdef WITH_X86
 	{
 		_T("sb_isa"), _T("SoundBlaster ISA (Creative)"), NULL,
 		NULL, isa_expansion_init, NULL, NULL, ROMTYPE_SBISA | ROMTYPE_NOT, 0, 0, BOARD_NONAUTOCONFIG_BEFORE, true,
@@ -5997,7 +6004,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, sb_isa_settings
 	},
-
+#endif
 
 #if 0
 	{
@@ -6100,6 +6107,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, ethernet_settings,
 	},
+#ifdef WITH_X86
 	{
 		_T("ne2000_isa"), _T("RTL8019 ISA (NE2000 compatible)"), NULL,
 		NULL, isa_expansion_init, NULL, NULL, ROMTYPE_NE2KISA | ROMTYPE_NOT, 0, 0, BOARD_NONAUTOCONFIG_BEFORE, true,
@@ -6108,6 +6116,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, ne2k_isa_settings
 	},
+#endif
 #ifdef CATWEASEL
 
 		/* Catweasel */
@@ -6147,6 +6156,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, cubo_settings,
 	},
+#ifdef WITH_X86
 	{
 		_T("x86_mouse"), _T("x86 Bridgeboard mouse"), NULL,
 		NULL, isa_expansion_init, NULL, NULL, ROMTYPE_X86MOUSE | ROMTYPE_NOT, 0, 0, BOARD_NONAUTOCONFIG_BEFORE, true,
@@ -6155,7 +6165,7 @@ const struct expansionromtype expansionroms[] = {
 		0, 0, 0, false, NULL,
 		false, 0, x86_mouse_settings
 	},
-
+#endif
 
 	{
 		NULL

--- a/src/gfxboard.cpp
+++ b/src/gfxboard.cpp
@@ -7,6 +7,8 @@
 *
 */
 
+#ifdef GFXBOARD
+
 #define VRAMLOG 0
 #define MEMLOGR 0
 #define MEMLOGW 0
@@ -56,11 +58,12 @@ static bool memlogw = true;
 #include "qemuvga/qemuuaeglue.h"
 #include "qemuvga/vga.h"
 
+#ifdef WITH_X86
 extern void put_io_pcem(uaecptr, uae_u32, int);
 extern uae_u32 get_io_pcem(uaecptr, int);
 extern void put_mem_pcem(uaecptr, uae_u32, int);
 extern uae_u32 get_mem_pcem(uaecptr, int);
-
+#endif
 
 #define MONITOR_SWITCH_DELAY 25
 
@@ -139,6 +142,7 @@ static const struct gfxboard boards[] =
 		0x00000000, 0x00200000, 0x00200000, 0x10000, 0, 0, 2, false,
 		0, 0xc1, &a2410_func
 	},
+#ifdef WITH_X86
 	{
 		GFXBOARD_ID_SPECTRUM_Z2,
 		_T("Spectrum 28/24 [Zorro II]"), _T("Great Valley Products"), _T("Spectrum28/24_Z2"),
@@ -232,6 +236,7 @@ static const struct gfxboard boards[] =
 		ROMTYPE_PICASSOIV,
 		0, NULL, &gd5446_device
 	},
+#endif
 	{
 		GFXBOARD_ID_HARLEQUIN,
 		_T("Harlequin [Zorro II]"), _T("ACS"), _T("Harlequin_PAL"),
@@ -247,6 +252,7 @@ static const struct gfxboard boards[] =
 		0, 0xc1, &a2410_func
 	},
 #endif
+#ifdef WITH_X86
 	{
 		GFXBOARD_ID_VOODOO3_PCI,
 		_T("Voodoo 3 3000 [PCI]"), _T("3dfx"), _T("V3_3000"),
@@ -276,6 +282,7 @@ static const struct gfxboard boards[] =
 		0x00000000, 0x00200000, 0x00200000, 0x00400000, CIRRUS_ID_CLGD5434, 2, 0, false,
 		0, 0, NULL, &gd5434_vlb_swapped_device
 	},
+#endif
 	{
 		NULL
 	}
@@ -497,6 +504,7 @@ static const addrbank tmpl_gfxboard_bank_special = {
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
 
+#ifdef WITH_X86
 static const addrbank tmpl_gfxboard_bank_vram_pcem = {
 	gfxboard_lget_vram_pcem, gfxboard_wget_vram_pcem, gfxboard_bget_vram_pcem,
 	gfxboard_lput_vram_pcem, gfxboard_wput_vram_pcem, gfxboard_bput_vram_pcem,
@@ -608,6 +616,7 @@ static const addrbank tmpl_gfxboard_bank_special_pcem = {
 	dummy_lgeti, dummy_wgeti,
 	ABFLAG_IO | ABFLAG_SAFE, S_READ, S_WRITE
 };
+#endif
 
 static void REGPARAM2 dummy_lput(uaecptr addr, uae_u32 l)
 {
@@ -1801,6 +1810,7 @@ static void reset_pci (struct rtggfxboard *gb)
 	gb->p4i2c = 0xff;
 }
 
+#ifdef WITH_X86
 static void picassoiv_checkswitch (struct rtggfxboard *gb)
 {
 	if (ISP4()) {
@@ -1824,6 +1834,7 @@ static void picassoiv_checkswitch (struct rtggfxboard *gb)
 		gb->monswitch_reset = false;
 	}
 }
+#endif
 
 static void bput_regtest (struct rtggfxboard *gb, uaecptr addr, uae_u8 v)
 {
@@ -1838,7 +1849,9 @@ static void bput_regtest (struct rtggfxboard *gb, uaecptr addr, uae_u8 v)
 	if (!(gb->vga.vga.sr[0x07] & 0x01) && gb->vram_enabled) {
 		remap_vram (gb, gb->vram_offset[0], gb->vram_offset[1], false);
 	}
+#ifdef WITH_X86
 	picassoiv_checkswitch (gb);
+#endif
 }
 
 static uae_u8 bget_regtest (struct rtggfxboard *gb, uaecptr addr, uae_u8 v)
@@ -3522,7 +3535,9 @@ static void REGPARAM2 gfxboards_bput_regs (uaecptr addr, uae_u32 v)
 	if (gb->picassoiv_bank & PICASSOIV_BANK_UNMAPFLASH) {
 		if (addr == 0x404) {
 			gb->picassoiv_flifi = b;
+#ifdef WITH_X86
 			picassoiv_checkswitch (gb);
+#endif
 		} else if (addr == 0x406) {
 			gb->p4i2c = b;
 		}
@@ -3618,6 +3633,7 @@ static void pci_change_config(struct pci_board_state *pci)
 	}
 }
 
+#ifdef WITH_X86
 static void REGPARAM2 voodoo3_io_lput(struct pci_board_state *pcibs, uaecptr addr, uae_u32 b)
 {
 	put_io_pcem(addr, b, 2);
@@ -4072,7 +4088,7 @@ static const struct pci_board s3virge_pci_board =
 	true,
 	get_pci_pcem, put_pci_pcem, pci_change_config
 };
-
+#endif
 
 int gfxboard_get_index_from_id(int id)
 {
@@ -4445,6 +4461,7 @@ bool gfxboard_init_memory (struct autoconfig_info *aci)
 	memcpy(&gb->gfxboard_bank_special, &tmpl_gfxboard_bank_special, sizeof(addrbank));
 	memcpy(&gb->gfxboard_bank_memory_nojit, &tmpl_gfxboard_bank_memory_nojit, sizeof(addrbank));
 
+#ifdef WITH_X86
 	memcpy(&gb->gfxboard_bank_vram_pcem, &tmpl_gfxboard_bank_vram_pcem, sizeof(addrbank));
 	memcpy(&gb->gfxboard_bank_vram_normal_pcem, &tmpl_gfxboard_bank_vram_normal_pcem, sizeof(addrbank));
 	memcpy(&gb->gfxboard_bank_vram_wordswap_pcem, &tmpl_gfxboard_bank_vram_wordswap_pcem, sizeof(addrbank));
@@ -4460,6 +4477,7 @@ bool gfxboard_init_memory (struct autoconfig_info *aci)
 	memcpy(&gb->gfxboard_bank_mmio_lbs_pcem, &tmpl_gfxboard_bank_mmio_lbs_pcem, sizeof(addrbank));
 	memcpy(&gb->gfxboard_bank_special_pcem, &tmpl_gfxboard_bank_special_pcem, sizeof(addrbank));
 	memcpy(&gb->gfxboard_bank_bios, &tmpl_gfxboard_bank_bios, sizeof(addrbank));
+#endif
 
 	gb->gfxboard_bank_memory.name = gb->memorybankname;
 	gb->gfxboard_bank_memory_nojit.name = gb->memorybanknamenojit;
@@ -4478,10 +4496,12 @@ bool gfxboard_init_memory (struct autoconfig_info *aci)
 
 		TCHAR path[MAX_DPATH];
 		fetch_rompath(path, sizeof(path) / sizeof(TCHAR));
+#ifdef WITH_X86
 		if (gb->rbc->rtgmem_type == GFXBOARD_ID_VOODOO3_PCI || gb->rbc->rtgmem_type == GFXBOARD_ID_VOODOO5_PCI)
 			_tcscat(path, _T("voodoo3.rom"));
 		else
 			_tcscat(path, _T("s3virge.rom"));
+#endif
 		struct zfile *zf = read_rom_name(path);
 		if (zf) {
 			gb->bios = xcalloc(uae_u8, 65536);
@@ -4501,10 +4521,12 @@ bool gfxboard_init_memory (struct autoconfig_info *aci)
 		gb->configured_regs = 1;
 		struct pci_bridge *b = pci_bridge_get();
 		if (b) {
+#ifdef WITH_X86
 			if (gb->rbc->rtgmem_type == GFXBOARD_ID_VOODOO3_PCI || gb->rbc->rtgmem_type == GFXBOARD_ID_VOODOO5_PCI)
 				gb->pcibs = pci_board_add(b, &voodoo3_pci_board, -1, 0, aci, gb);
 			else
 				gb->pcibs = pci_board_add(b, &s3virge_pci_board, -1, 0, aci, gb);
+#endif
 		}
 		gb->gfxboard_intena = 1;
 		return true;
@@ -5065,7 +5087,7 @@ static void REGPARAM2 gfxboard_lput_vram_p4z2_pcem(uaecptr addr, uae_u32 l)
 
 
 
-
+#ifdef WITH_X86
 static uae_u32 REGPARAM2 gfxboard_lget_io_pcem(uaecptr addr)
 {
 	struct rtggfxboard *gb = getgfxboard(addr);
@@ -5204,7 +5226,7 @@ static void REGPARAM2 gfxboard_bput_io_swap2_pcem(uaecptr addr, uae_u32 b)
 	addr ^= 3;
 	put_io_pcem(addr, b, 0);
 }
-
+#endif
 
 void put_pci_pcem(uaecptr addr, uae_u8 v);
 uae_u8 get_pci_pcem(uaecptr addr);
@@ -5247,6 +5269,7 @@ static void REGPARAM2 gfxboard_lput_pci_pcem(uaecptr addr, uae_u32 l)
 }
 
 
+#ifdef WITH_X86
 static uae_u32 REGPARAM2 gfxboard_bget_mmio_pcem(uaecptr addr)
 {
 	struct rtggfxboard *gb = getgfxboard(addr);
@@ -5969,6 +5992,7 @@ static void REGPARAM2 gfxboard_lput_special_pcem(uaecptr addr, uae_u32 l)
 {
 	special_pcem_put(addr, l, 2);
 }
+#endif
 
 void *pcem_getvram(int size)
 {
@@ -6062,3 +6086,5 @@ void gfxboard_freertgbuffer(int monid, uae_u8 *dst)
 
 	xfree(dst);
 }
+
+#endif

--- a/src/idecontrollers.cpp
+++ b/src/idecontrollers.cpp
@@ -3043,6 +3043,7 @@ void dev_hd_add_ide_unit(int ch, struct uaedev_config_info* ci, struct romconfig
 }
 
 
+#ifdef WITH_X86
 extern void x86_xt_ide_bios(struct zfile*, struct romconfig*);
 static bool x86_at_hd_init(struct autoconfig_info *aci, int type)
 {
@@ -3173,3 +3174,4 @@ uae_u16 x86_ide_hd_get(int portnum, int size)
 	}
 	return v;
 }
+#endif

--- a/src/include/x86.h
+++ b/src/include/x86.h
@@ -13,7 +13,9 @@ bool a2386_init(struct autoconfig_info *aci);
 bool isa_expansion_init(struct autoconfig_info *aci);
 void x86_bridge_sync_change(void);
 void x86_update_sound(float);
+#ifdef WITH_X86
 void x86_mouse(int port, int x, int y, int z, int b);
+#endif
 
 #define X86_STATE_INACTIVE 0
 #define X86_STATE_STOP 1

--- a/src/inputdevice.cpp
+++ b/src/inputdevice.cpp
@@ -3398,7 +3398,9 @@ static void mouseupdate (int pct, bool vsync)
 				pc_mouse_buttons[i] |= 4;
 			else
 				pc_mouse_buttons[i] &= ~4;
+#ifdef WITH_X86
 			x86_mouse(i, v1, v2, v3, pc_mouse_buttons[i]);
+#endif
 
 #if OUTPUTDEBUG
 			if (v1 || v2) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -545,6 +545,7 @@ void fixup_prefs (struct uae_prefs *p, bool userconfig)
 		error_log (_T("Unsupported CPU Board RAM size."));
 	}
 
+#if GFXBOARD
 	for (int i = 0; i < MAX_RTG_BOARDS; i++) {
 		struct rtgboardconfig *rbc = &p->rtgboards[i];
 		if (p->chipmem.size > 0x200000 && rbc->rtgmem_size && gfxboard_get_configtype(rbc) == 2) {
@@ -575,6 +576,7 @@ void fixup_prefs (struct uae_prefs *p, bool userconfig)
 			rbc->rtgmem_size = 0;
 		}
 	}
+#endif
 
 	if (p->cs_z3autoconfig && p->address_space_24) {
 		p->cs_z3autoconfig = false;

--- a/src/od-fs/fsvideo.cpp
+++ b/src/od-fs/fsvideo.cpp
@@ -2043,7 +2043,9 @@ bool toggle_rtg (int monid, int mode)
 		}
 		if (rtg_index < 0) {
 			if (ad->picasso_on) {
+#ifdef GFXBOARD
 				gfxboard_rtg_disable(monid, old_index);
+#endif
 				ad->picasso_requested_on = false;
 				// statusline_add_message(STATUSTYPE_DISPLAY, _T("Chipset display"));
 				set_config_changed();
@@ -2054,7 +2056,10 @@ bool toggle_rtg (int monid, int mode)
 		struct rtgboardconfig *r = &currprefs.rtgboards[rtg_index];
 		if (r->rtgmem_size > 0 && r->monitor_id == monid) {
 			if (r->rtgmem_type >= GFXBOARD_HARDWARE) {
-				int idx = gfxboard_toggle(r->monitor_id, rtg_index, mode >= -1);
+				int idx = -1;
+#if GFXBOARD
+				gfxboard_toggle(r->monitor_id, rtg_index, mode >= -1);
+#endif
 				if (idx >= 0) {
 					rtg_index = idx;
 					return true;
@@ -2064,11 +2069,15 @@ bool toggle_rtg (int monid, int mode)
 					return false;
 				}
 			} else {
+#if GFXBOARD
 				gfxboard_toggle(r->monitor_id, -1, -1);
+#endif
 				if (mode < -1)
 					return true;
 				devices_unsafeperiod();
+#ifdef GFXBOARD
 				gfxboard_rtg_disable(monid, old_index);
+#endif
 				// can always switch from RTG to custom
 				if (ad->picasso_requested_on && ad->picasso_on) {
 					ad->picasso_requested_on = false;

--- a/src/od-win32/mman.cpp
+++ b/src/od-win32/mman.cpp
@@ -416,7 +416,11 @@ static int doinit_shm (void)
 	align = 16 * 1024 * 1024 - 1;
 	totalsize = 0x01000000;
 
+#ifdef GFXBOARD
 	z3rtgmem_size = gfxboard_get_configtype(rbc) == 3 ? rbc->rtgmem_size : 0;
+#else
+	z3rtgmem_size = 0;
+#endif
 
 	if (p->cpu_model >= 68020)
 		totalsize = 0x10000000;
@@ -589,6 +593,7 @@ static int doinit_shm (void)
 	p96mem_size = z3rtgmem_size;
 	p96base_offset = 0;
 	uae_u32 z3rtgallocsize = 0;
+#ifdef GFXBOARD
 	if (rbc->rtgmem_size && gfxboard_get_configtype(rbc) == 3) {
 		z3rtgallocsize = gfxboard_get_autoconfig_size(rbc) < 0 ? rbc->rtgmem_size : gfxboard_get_autoconfig_size(rbc);
 		if (changed_prefs.z3autoconfig_start == Z3BASE_UAE)
@@ -600,6 +605,7 @@ static int doinit_shm (void)
 	} else if (rbc->rtgmem_size && gfxboard_get_configtype(rbc) == 1) {
 		p96base_offset = 0xa80000;
 	}
+#endif
 	if (p96base_offset) {
 		if (jit_direct_compatible_memory) {
 			p96mem_offset = natmem_offset + p96base_offset;
@@ -621,6 +627,7 @@ static int doinit_shm (void)
 				addr = expansion_startaddress(addr, changed_prefs.z3fastmem2_size);
 				addr += changed_prefs.z3fastmem2_size;
 				addr = expansion_startaddress(addr, z3rtgallocsize);
+#ifdef GFXBOARD
 				if (gfxboard_get_configtype(rbc) == 3) {
 					p96base_offset = addr;
 					write_log("NATMEM: p96base_offset = 0x%x\n", p96base_offset);
@@ -634,6 +641,7 @@ static int doinit_shm (void)
 						p96mem_offset = natmem_offset + p96base_offset;
 					}
 				}
+#endif
 			}
 		}
 	}

--- a/src/od-win32/picasso96_win.cpp
+++ b/src/od-win32/picasso96_win.cpp
@@ -983,6 +983,7 @@ static void rtg_render(void)
 			// flushed = true;
 #endif
 		}
+#ifdef GFXBOARD
 		gfxboard_vsync_handler(full, true);
 		if (currprefs.rtg_multithread && uaegfx_active) {
 			if (ad->pending_render) {
@@ -991,6 +992,7 @@ static void rtg_render(void)
 			}
 			write_comm_pipe_int(render_pipe, uaegfx_index, 0);
 		}
+#endif
 	}
 }
 static void rtg_clear(int monid)
@@ -1214,11 +1216,13 @@ void picasso_refresh(int monid)
 	setupcursor();
 	rtg_clear(monid);
 
+#ifdef GFXBOARD
 	if (currprefs.rtgboards[0].rtgmem_type >= GFXBOARD_HARDWARE) {
 		gfxboard_refresh(monid);
 		unlockrtg();
 		return;
 	}
+#endif
 
 	/* Make sure that the first time we show a Picasso video mode, we don't blit any crap.
 	* We can do this by checking if we have an Address yet. 
@@ -1438,7 +1442,9 @@ void picasso_handle_hsync(void)
 				}
 				picasso_trigger_vblank();
 			}
+#ifdef GFXBOARD
 			gfxboard_vsync_handler(false, false);
+#endif
 		} else {
 			picasso_handle_vsync2(mon);
 		}

--- a/src/od-win32/win32gfx.cpp
+++ b/src/od-win32/win32gfx.cpp
@@ -4200,7 +4200,9 @@ bool toggle_rtg (int monid, int mode)
 		}
 		if (rtg_index < 0) {
 			if (ad->picasso_on) {
+#ifdef GFXBOARD
 				gfxboard_rtg_disable(monid, old_index);
+#endif
 				ad->picasso_requested_on = false;
 				statusline_add_message(STATUSTYPE_DISPLAY, _T("Chipset display"));
 				set_config_changed();
@@ -4225,7 +4227,9 @@ bool toggle_rtg (int monid, int mode)
 				if (mode < -1)
 					return true;
 				devices_unsafeperiod();
+#ifdef GFXBOARD
 				gfxboard_rtg_disable(monid, old_index);
+#endif
 				// can always switch from RTG to custom
 				if (ad->picasso_requested_on && ad->picasso_on) {
 					ad->picasso_requested_on = false;

--- a/src/scsi.cpp
+++ b/src/scsi.cpp
@@ -5682,6 +5682,7 @@ void overdrive_add_scsi_unit(int ch, struct uaedev_config_info *ci, struct romco
 	generic_soft_scsi_add(ch, ci, rc, NCR5380_OVERDRIVE, 65536, 32768, ROMTYPE_OVERDRIVE);
 }
 
+#ifdef WITH_X86
 // x86 bridge scsi rancho rt1000
 void x86_rt1000_bput(int portnum, uae_u8 v)
 {
@@ -5735,3 +5736,4 @@ void x86_rt1000_add_unit(int ch, struct uaedev_config_info *ci, struct romconfig
 {
 	generic_soft_scsi_add(ch, ci, rc, NCR5380_X86_RT1000, 0, 0, ROMTYPE_X86_RT1000);
 }
+#endif

--- a/src/x86.cpp
+++ b/src/x86.cpp
@@ -3258,6 +3258,7 @@ static void ne2000_isa_irq_callback(struct pci_board_state *pcibs, bool irq)
 		x86_clearirq(xb->ne2000_irq);
 }
 
+#ifdef WITH_X86
 void x86_rt1000_bios(struct zfile *z, struct romconfig *rc)
 {
 	struct x86_bridge *xb = bridges[0];
@@ -3293,6 +3294,7 @@ void x86_xt_ide_bios(struct zfile *z, struct romconfig *rc)
 	zfile_fread(xtiderom, 1, 0x4000, z);
 	mem_mapping_add(&bios_mapping[5], addr, 0x4000, mem_read_romext2, mem_read_romextw2, mem_read_romextl2, mem_write_null, mem_write_nullw, mem_write_nulll, xtiderom, MEM_MAPPING_EXTERNAL | MEM_MAPPING_ROM, 0);
 }
+#endif
 
 void *sb_1_init();
 void *sb_15_init();
@@ -3518,6 +3520,7 @@ static void set_vga(struct x86_bridge *xb)
 void mouse_serial_poll(int x, int y, int z, int b, void *p);
 void mouse_ps2_poll(int x, int y, int z, int b, void *p);
 
+#ifdef WITH_X86
 void x86_mouse(int port, int x, int y, int z, int b)
 {
 	struct x86_bridge *xb = bridges[0];
@@ -3535,6 +3538,7 @@ void x86_mouse(int port, int x, int y, int z, int b)
 		break;
 	}
 }
+#endif
 
 void *mouse_serial_init();
 void *mouse_ps2_init();


### PR DESCRIPTION
On Apple Silicon, WITH_X86 was correctly NOT defined but some of the code did not compile correctly with this turned off.

Also, GFXBOARD support can’t compile without WITH_X86 so this is now correctly handled too and the code now also compiles correctly when GFXBOARD support is off.

configure.ac was also updated to autoconf version 2.72.

I tried to tread a lightly as I could with this since I can't test most of it past compilation.